### PR TITLE
Add anchored comment indicators to document editor

### DIFF
--- a/src/components/documents/document-editor.tsx
+++ b/src/components/documents/document-editor.tsx
@@ -20,7 +20,7 @@ import { Markdown } from "tiptap-markdown";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { updateDocumentContent } from "@/lib/db/mutations/documents";
-import type { ActionState } from "@/lib/utils";
+import { cn, type ActionState } from "@/lib/utils";
 
 interface SelectionSnapshot {
   text: string;
@@ -35,6 +35,15 @@ interface DocumentEditorProps {
   updatedAt: string;
   canEdit: boolean;
   onSelectionChange?: (selection: SelectionSnapshot | null) => void;
+  anchors?: {
+    id: string;
+    kind: "annotation" | "suggestion";
+    status: "open" | "resolved";
+    suggestionStatus: "pending" | "approved" | "rejected" | null;
+    start: number | null;
+    end: number | null;
+    text: string | null;
+  }[];
 }
 
 type EditorActionState = ActionState;
@@ -60,6 +69,7 @@ export const DocumentEditor = ({
   updatedAt,
   canEdit,
   onSelectionChange,
+  anchors,
 }: DocumentEditorProps) => {
   const [markdown, setMarkdown] = useState(initialContent);
   const [state, formAction, isPending] = useActionState<EditorActionState, FormData>(
@@ -200,6 +210,156 @@ export const DocumentEditor = ({
 
   const characterCount = markdown.length;
 
+  const anchorIndicators = useMemo(() => {
+    if (!anchors?.length) return [] as {
+      id: string;
+      kind: "annotation" | "suggestion";
+      status: "open" | "resolved";
+      suggestionStatus: "pending" | "approved" | "rejected" | null;
+      start: number;
+      text: string | null;
+      ratio: number;
+      stackIndex: number;
+      stackSize: number;
+    }[];
+
+    const resolved = anchors
+      .map((anchor) => {
+        let start =
+          anchor.start != null && anchor.start >= 0 ? anchor.start : null;
+
+        if (start == null && anchor.text) {
+          const rawIndex = markdown.indexOf(anchor.text);
+          if (rawIndex >= 0) {
+            start = rawIndex;
+          } else {
+            const trimmed = anchor.text.trim();
+            if (trimmed) {
+              const trimmedIndex = markdown.indexOf(trimmed);
+              if (trimmedIndex >= 0) {
+                start = trimmedIndex;
+              }
+            }
+          }
+        }
+
+        if (start == null) return null;
+
+        return {
+          id: anchor.id,
+          kind: anchor.kind,
+          status: anchor.status,
+          suggestionStatus: anchor.suggestionStatus,
+          start,
+          text: anchor.text,
+        };
+      })
+      .filter((entry): entry is {
+        id: string;
+        kind: "annotation" | "suggestion";
+        status: "open" | "resolved";
+        suggestionStatus: "pending" | "approved" | "rejected" | null;
+        start: number;
+        text: string | null;
+      } => entry !== null)
+      .sort((a, b) => a.start - b.start);
+
+    if (!resolved.length) return [];
+
+    const total = Math.max(characterCount, 1);
+    const grouped = new Map<number, typeof resolved>();
+
+    for (const entry of resolved) {
+      const group = grouped.get(entry.start) ?? [];
+      group.push(entry);
+      grouped.set(entry.start, group);
+    }
+
+    const output: {
+      id: string;
+      kind: "annotation" | "suggestion";
+      status: "open" | "resolved";
+      suggestionStatus: "pending" | "approved" | "rejected" | null;
+      start: number;
+      text: string | null;
+      ratio: number;
+      stackIndex: number;
+      stackSize: number;
+    }[] = [];
+
+    Array.from(grouped.entries())
+      .sort((a, b) => a[0] - b[0])
+      .forEach(([start, entries]) => {
+        entries.forEach((entry, index) => {
+          const ratio = Math.min(Math.max(entry.start / total, 0), 1);
+          output.push({
+            ...entry,
+            ratio,
+            stackIndex: index,
+            stackSize: entries.length,
+          });
+        });
+      });
+
+    return output;
+  }, [anchors, markdown, characterCount]);
+
+  const renderAnchorIndicators = () => {
+    if (!anchorIndicators.length) return null;
+
+    return (
+      <div className="pointer-events-none absolute inset-y-4 right-2 z-10 w-8">
+        <span className="sr-only" aria-live="polite">
+          {anchorIndicators.length} anchored {anchorIndicators.length === 1 ? "comment" : "comments"} in this
+          document.
+        </span>
+        {anchorIndicators.map((indicator) => {
+          const colorClass =
+            indicator.kind === "suggestion"
+              ? indicator.suggestionStatus === "approved"
+                ? "bg-emerald-500"
+                : indicator.suggestionStatus === "rejected"
+                  ? "bg-rose-500"
+                  : "bg-amber-500"
+              : indicator.status === "resolved"
+                ? "bg-muted-foreground/50"
+                : "bg-sky-500";
+
+          const titleParts = [
+            indicator.kind === "suggestion" ? "Suggestion" : "Annotation",
+            indicator.status === "resolved" ? "(resolved)" : null,
+            indicator.kind === "suggestion" && indicator.suggestionStatus
+              ? `(${indicator.suggestionStatus})`
+              : null,
+          ].filter(Boolean);
+
+          const snippet = indicator.text?.trim().replace(/\s+/g, " ") ?? "";
+
+          return (
+            <span
+              key={`${indicator.id}-${indicator.stackIndex}`}
+              className={cn(
+                "pointer-events-auto absolute flex size-2 items-center justify-center rounded-full border border-background/80 shadow",
+                colorClass
+              )}
+              style={{
+                top: `calc(${(indicator.ratio * 100).toFixed(2)}%)`,
+                right: `${indicator.stackIndex * 0.6}rem`,
+                transform: "translateY(-50%)",
+              }}
+              title={`${titleParts.join(" ")}${snippet ? ` • “${snippet.slice(0, 80)}${
+                snippet.length > 80 ? "…" : ""
+              }”` : ""}`}
+              aria-label={`${titleParts.join(" ")}${
+                snippet ? ` anchored to ${snippet.slice(0, 80)}` : ""
+              }`}
+            />
+          );
+        })}
+      </div>
+    );
+  };
+
   const resetToLastSaved = () => {
     if (!editor || !canEdit) return;
     editor.commands.setContent(initialContent, { emitUpdate: false });
@@ -230,8 +390,9 @@ export const DocumentEditor = ({
           <input type="hidden" name="content" value={markdown} />
           <motion.div
             layout
-            className="rounded-xl border border-border/60 bg-background/80 shadow-inner"
+            className="relative rounded-xl border border-border/60 bg-background/80 shadow-inner"
           >
+            {renderAnchorIndicators()}
             <EditorContent editor={editor} className="p-4" />
           </motion.div>
           <div className="flex flex-wrap items-center justify-between gap-3">
@@ -262,8 +423,9 @@ export const DocumentEditor = ({
       ) : (
         <motion.div
           layout
-          className="rounded-xl border border-border/60 bg-background/80 p-6 shadow-inner"
+          className="relative rounded-xl border border-border/60 bg-background/80 p-6 shadow-inner"
         >
+          {renderAnchorIndicators()}
           <EditorContent editor={editor} />
         </motion.div>
       )}

--- a/src/components/documents/document-workspace.tsx
+++ b/src/components/documents/document-workspace.tsx
@@ -54,6 +54,24 @@ export const DocumentWorkspace = ({
 }: DocumentWorkspaceProps) => {
   const [selection, setSelection] = useState<SelectionSnapshot | null>(null);
 
+  const anchoredComments = useMemo(() => {
+    const flatten = (threads: CommentThread[]): CommentThread[] => {
+      return threads.flatMap((thread) => [thread, ...flatten(thread.replies ?? [])]);
+    };
+
+    return flatten(comments)
+      .filter((comment) => comment.anchorStart != null || (comment.anchorText && comment.anchorText.trim().length > 0))
+      .map((comment) => ({
+        id: comment.id,
+        kind: comment.kind,
+        status: comment.status,
+        suggestionStatus: comment.suggestionStatus,
+        start: comment.anchorStart,
+        end: comment.anchorEnd,
+        text: comment.anchorText,
+      }));
+  }, [comments]);
+
   const activeCollaborator = useMemo(() => {
     return document.collaborators.find(
       (collaborator) =>
@@ -93,6 +111,7 @@ export const DocumentWorkspace = ({
               updatedAt={document.updatedAt}
               canEdit={viewer.isOwner}
               onSelectionChange={setSelection}
+              anchors={anchoredComments}
             />
           </div>
         </SharedTransition>


### PR DESCRIPTION
## Summary
- surface anchored annotations and suggestions within the document editor via subtle gutter indicators with tooltips
- aggregate anchored comment metadata in the workspace and feed it into the editor to drive the markers

## Testing
- pnpm lint *(fails: prompts for initial Next.js lint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68cde780c690832aa72e245005523f07